### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,24 +1,24 @@
 Image-Zoomer
 ==========
 --------
-###Specs
+### Specs
 [![Bintray](https://img.shields.io/badge/Bintray-v1.0.2-brightgreen.svg?)](https://bintray.com/code-crusher/maven/ImageZoomer)
 <a href="http://www.methodscount.com/?lib=com.vatsal.imagezoomer%3Aimage-zoomer%3A1.0.2"><img src="https://img.shields.io/badge/Methods%20and%20size-core:%20103%20%7C%2026%20KB-e91e63.svg"/></a>
 <a href="http://twitter.com/vatsal__bajpai"><img src="https://img.shields.io/badge/Twitter-@vatsal__bajpai-blue.svg?" alt="Twitter" data-canonical-src="https://img.shields.io/badge/Twitter-@vatsal__bajpai-blue.svg?" style="max-width:100%;"></a><br>
 
 Image zoomer provides easy way to add zoom animations to you ImageButton. You can set the animation duration and reverse mode to reverse the animation.
 
-###Featured in
+### Featured in
 <a href="http://android-arsenal.com/details/1/3799"><img src="https://img.shields.io/badge/Android%20Arsenal-ImageZoomer-green.svg"/></a>
 
-#Screenshots
-###Zoom
+# Screenshots
+### Zoom
 ![Screenshot](https://github.com/code-crusher/Image-Zoomer/blob/master/screenshots/zoom.gif)
 
-###Zoom Reverse
+### Zoom Reverse
 ![Screenshot](https://github.com/code-crusher/Image-Zoomer/blob/master/screenshots/zoomReverse.gif)
 
-#Integration
+# Integration
 -------------
 
  - ImageZoomer is available in the MavenCentral, so getting it as simple as adding it as a dependency
@@ -27,8 +27,8 @@ Image zoomer provides easy way to add zoom animations to you ImageButton. You ca
 compile 'com.vatsal.imagezoomer:image-zoomer:1.0.2'
 ```
 
-#Usage
-###Method 1 : XML
+# Usage
+### Method 1 : XML
 In your activity_main.xml file use this code instead of ImageButton:
 
 ```xml  
@@ -37,7 +37,7 @@ In your activity_main.xml file use this code instead of ImageButton:
     android:layout_height="wrap_content"
     android:src="@mipmap/ic_launcher" />
 ```
-###Attributes
+### Attributes
 
 <ul>• To set the duration use:
 </ul>
@@ -50,7 +50,7 @@ In your activity_main.xml file use this code instead of ImageButton:
     app:modeReverse="true"
 ```
 
-###Method 2 : Java
+### Method 2 : Java
 In your MainActivity.class use this code in OnClick() of ImageButton:
 
 ```Java
@@ -87,7 +87,7 @@ image_button | ImageButton
 activity    | Activity
 duration(ms)     | long
 
-#License
+# License
 
 > Copyright 2016 Vatsal Bajpai
 


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
